### PR TITLE
fix: add two more patterns to change cfgMap name during freeze

### DIFF
--- a/engine/processor/freeze.go
+++ b/engine/processor/freeze.go
@@ -53,6 +53,8 @@ func init() {
 		kindStatefulSet,
 	} {
 		configMap[kind] = []string{
+			"spec.template.spec.containers[*].env[*].valueFrom.configMapKeyRef.name",
+			"spec.template.spec.containers[*].envFrom[*].configMapRef.name",
 			"spec.template.spec.volumes[*].configMap.name",
 		}
 		secret[kind] = []string{

--- a/example/nginx-with-data-from-file.rendered+frozen.yml
+++ b/example/nginx-with-data-from-file.rendered+frozen.yml
@@ -26,7 +26,16 @@ spec:
         app: app
     spec:
       containers:
-      - image: nginx:1.7.9
+      - env:
+        - name: ROBOTS_TXT
+          valueFrom:
+            configMapKeyRef:
+              key: robots.txt
+              name: app-fba46ca
+        envFrom:
+        - configMapRef:
+            name: app-fba46ca
+        image: nginx:1.7.9
         name: nginx
         ports:
         - containerPort: 80

--- a/example/nginx-with-data-from-file.rendered.yml
+++ b/example/nginx-with-data-from-file.rendered.yml
@@ -26,7 +26,16 @@ spec:
         app: app
     spec:
       containers:
-      - image: nginx:1.7.9
+      - env:
+        - name: ROBOTS_TXT
+          valueFrom:
+            configMapKeyRef:
+              key: robots.txt
+              name: app
+        envFrom:
+        - configMapRef:
+            name: app
+        image: nginx:1.7.9
         name: nginx
         ports:
         - containerPort: 80

--- a/example/nginx-with-data-from-file.yml
+++ b/example/nginx-with-data-from-file.yml
@@ -31,6 +31,15 @@ spec:
         volumeMounts:
         - name: $NAME-volume
           mountPath: /usr/share/nginx/html
+        envFrom:
+        - configMapRef:
+            name: $NAME
+        env:
+        - name: ROBOTS_TXT
+          valueFrom:
+            configMapKeyRef:
+              name: $NAME
+              key: robots.txt
       volumes:
       - configMap:
           name: $NAME


### PR DESCRIPTION
Hi, @shyiko I've added two more patterns for `--freeze` to alter when using `ConfigMap` with container environment variables. I've also updated the nginx example to demonstrate.

Let me know if i misunderstood the correct place to add these patterns :)